### PR TITLE
Delete quote in ingress definition

### DIFF
--- a/charts/activiti-keycloak/values.yaml
+++ b/charts/activiti-keycloak/values.yaml
@@ -15,7 +15,7 @@ keycloak:
 #        kubernetes.io/ingress.class: nginx
 #        nginx.ingress.kubernetes.io/rewrite-target: /
 #        nginx.ingress.kubernetes.io/configuration-snippet: |
-#          more_set_headers 'Access-Control-Allow-Methods: "POST, GET, OPTIONS, PUT, PATCH, DELETE"';
+#          more_set_headers 'Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, PATCH, DELETE';
 #          more_set_headers 'Access-Control-Allow-Credentials: true';
 #          more_set_headers 'Access-Control-Allow-Headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authorization"';
 #          more_set_headers 'Access-Control-Allow-Origin: $http_origin';


### PR DESCRIPTION
The quote in header  ``Access-Control-Allow-Methods: "POST, GET, OPTIONS, PUT, PATCH, DELETE"`` can make it imcompatible with Firefox , delete the quote to fix the bug

If the response header is ``"POST, GET, OPTIONS, PUT, PATCH, DELETE"`` literally , Firefox would take ``"POST`` as an allowed method instead of the actuall ``POST``.

I've test it on my cloud , when the ``quote`` is gone , my angular program would work perfectly well.